### PR TITLE
cargo: bump version-sync dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ proptest = { version = "0.8", optional = true }
 uuid = { version = "0.7", default_features = false }
 
 [dev-dependencies]
-version-sync = "0.7"
+version-sync = "0.8"
 uuid = "0.7"
 
 [features]


### PR DESCRIPTION
The new version 0.8.0 requires Rust 2018, which this project is already using.